### PR TITLE
Fix : TypeError: can't concat str to bytes

### DIFF
--- a/numap/core/usb_cs_interface.py
+++ b/numap/core/usb_cs_interface.py
@@ -60,5 +60,5 @@ class USBCSInterface(USBBaseActor):
     def get_descriptor(self, usb_type='fullspeed', valid=False):
         descriptor_type = DescriptorType.cs_interface
         length = len(self.cs_config) + 2
-        response = struct.pack('BB', length & 0xff, descriptor_type) + self.cs_config
+        response = struct.pack('BB', length & 0xff, descriptor_type) + self.cs_config.encode("utf-8")
         return response


### PR DESCRIPTION
Type error problem fixed by encoding to bytes
```
TypeError: can't concat str to bytes
```